### PR TITLE
Add fleet.yaml

### DIFF
--- a/chart/widgetfactory/fleet.yaml
+++ b/chart/widgetfactory/fleet.yaml
@@ -1,0 +1,13 @@
+#Create K8s Namespace in-line with Helm chart deployment
+defaultNamespace: widget-factory
+
+# This diff accounts for sslip.io being used on the Ingress resource (the Fleet repo will get perpetually stuck in "Modified") 
+# and can safely be removed if not using an Ingress, or if using a fixed host for the Ingress resource.
+diff:
+  comparePatches:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    name: widgetfactory-chart-widgetfactory
+    namespace: widget-factory
+    operations:
+    - { "op": "remove", "path": "/spec/rules" }


### PR DESCRIPTION
Added `fleet.yaml` to take care of:

- Automatically creating the `widget-factory` Namespace
- Creating a diff to ignore the Ingress `/spec/rules` path that gets stuck in `Modified` due to using `sslip.io` as the Ingress domain